### PR TITLE
Use DIRECTORY_SEPARATOR

### DIFF
--- a/bin/pharen
+++ b/bin/pharen
@@ -1,8 +1,8 @@
 #! /usr/bin/env php
 <?php
 $dir = dirname(__FILE__);
-$pharen_dir = substr($dir, 0, strrpos($dir, "/"));
-include($pharen_dir."/pharen.php");
+$pharen_dir = substr($dir, 0, strrpos($dir, DIRECTORY_SEPARATOR));
+include($pharen_dir.DIRECTORY_SEPARATOR."pharen.php");
 
 if(__FILE__ === realpath($_SERVER['SCRIPT_NAME'])){
     $input_files = array();

--- a/pharen.php
+++ b/pharen.php
@@ -3,7 +3,7 @@ error_reporting(E_ALL | E_NOTICE);
 define("COMPILER_SYSTEM", dirname(__FILE__));
 define("EXTENSION", ".phn");
 
-require_once(COMPILER_SYSTEM.'/lexical.php');
+require_once(COMPILER_SYSTEM.DIRECTORY_SEPARATOR.'lexical.php');
 require("lang.php");
 
 // Some utility functions for use in Pharen


### PR DESCRIPTION
Hey here's the same patch as before but this time a pull request.

Use DIRECTORY_SEPARATOR for better portability.
