### PR TITLE
Use relative path in lang.php for better portability

### DIFF
--- a/lang.php
+++ b/lang.php
@@ -1,4 +1,5 @@
 <?php
+require_once(dirname(__FILE__).'\lexical.php');
 Lexical::$scopes['lang'] = array();
 define("SYSTEM", dirname(__FILE__));
 require_once((SYSTEM . "/lexical.php"));

--- a/pharen.php
+++ b/pharen.php
@@ -756,9 +756,12 @@ class RootNode extends Node{
         if(!isset(Flags::$flags['no-import-lang']) or Flags::$flags['no-import-lang'] == False){
             $code .= $this->format_line("require_once('".COMPILER_SYSTEM.DIRECTORY_SEPARATOR."lang.php"."');");
         }else if(Flags::$flags['no-import-lang'] == True){
-            if(!isset(Flags::$flags['no-import-lexical']) or Flags::$flags['no-import-lexical'] == False){
-                $code .= $this->format_line("require_once('".COMPILER_SYSTEM.DIRECTORY_SEPARATOR."lexical.php"."');");
+            if(!isset(Flags::$flags['import-lexi-relative']) or Flags::$flags['import-lexi-relative'] == False){
+                $prefix = "'".COMPILER_SYSTEM."'";
+            } else {
+                $prefix = "dirname(__FILE__)";
             }
+            $code .= $this->format_line("require_once(".$prefix.".'".DIRECTORY_SEPARATOR."lexical.php"."');");
         }
 
         $code .= $this->scope->init_namespace_scope();
@@ -2013,9 +2016,9 @@ function compile($code, $root=Null){
 }
 
 $old_lang_setting = isset(Flags::$flags['no-import-lang']) ? Flags::$flags['no-import-lang'] : False;
-$old_lexi_setting = isset(Flags::$flags['no-import-lexical']) ? Flags::$flags['no-import-lexical'] : False;
+$old_lexi_setting = isset(Flags::$flags['import-lexi-relative']) ? Flags::$flags['import-lexi-relative'] : False;
 set_flag("no-import-lang");
-set_flag("no-import-lexical");
+set_flag("import-lexi-relative");
 $lang_code = compile_file(COMPILER_SYSTEM . "/lang.phn");
-set_flag("no-import-lexical", $old_lexi_setting);
+set_flag("import-lexi-relative", $old_lexi_setting);
 set_flag("no-import-lang", $old_lang_setting);


### PR DESCRIPTION
Previously we were using both a relative and an absolute path. As lexical.php is being require_once'd twice anyway, remove the instance that uses an absolute path.

EDIT 2011-01-15 02:09+00:00: Two more commits, works a bit better on Cygwin now.
