### PR TITLE
Adding try/catch clause

### DIFF
--- a/examples/test/pharen_tests.phn
+++ b/examples/test/pharen_tests.phn
@@ -9,7 +9,7 @@
   (print (. "Running test: " fname "\n"))
   (compile-file (. TESTS-DIR "/tests/" fname ".phn") (. TESTS-DIR "/tmp"))
   (require (. TESTS-DIR "/tmp/" fname ".php")))
-    
+
 (set-error-handler (lambda (errno errstr file line)
                            (throw (new ErrorException errstr errno 0 file line))
                            TRUE))
@@ -25,6 +25,7 @@
        "cond",
        "if",
        "function_definition",
+       "class",
        "lambdas",
        "plambda",
        "macros",

--- a/examples/test/pharen_tests.phn
+++ b/examples/test/pharen_tests.phn
@@ -16,7 +16,7 @@
 
 (fn check (expr expected) (test.check expr expected 1))
 
-(let [tests 
+(let [tests
       ["literals",
        "func_calls",
        "comments",
@@ -24,6 +24,7 @@
        "lists_and_dicts",
        "cond",
        "if",
+       "try",
        "function_definition",
        "class",
        "lambdas",

--- a/examples/test/tests/class.phn
+++ b/examples/test/tests/class.phn
@@ -1,0 +1,25 @@
+; Test class definition
+(ns TestClass)
+
+; Support blank class
+(class Blank)
+(check (inst? (new Blank) Blank) TRUE)
+
+; Support constructor
+(class A
+       (access public (local message ""))
+       (fn __construct (msg)
+         (def (-> this message) msg))
+       (fn msg ()
+         (-> this message)))
+
+(def obj (new A "Msg"))
+(check (-> obj message) "Msg")
+
+; Support extends
+(class-extends B A
+    (fn msg ()
+      (:: parent (msg))))
+(def obj (new B "B msg"))
+(check (-> obj (msg)) "B msg")
+(check (inst? obj A) TRUE)

--- a/examples/test/tests/try.phn
+++ b/examples/test/tests/try.phn
@@ -1,0 +1,59 @@
+(ns TestTry)
+(use Exception as Exception)
+
+; Default Exception
+(check 
+  (inst? (try 
+           (do (throw (new Exception)) NULL)
+           (catch Exception e e))
+         Exception)
+  TRUE)
+
+
+; Without return
+(try
+  (throw (new Exception))
+  (catch Exception e (check (inst? e Exception) TRUE)))
+
+; Inside function
+(fn exception ()
+  (try
+    (do (throw (new Exception "Custom")) NULL)
+    (catch Exception e (-> e (getMessage)))))
+(check (exception) "Custom")
+
+; Custom exception
+(class-extends DefException Exception)
+(check
+  (inst? (try
+           (do (throw (new DefException)) NULL)
+           (catch DefException e e))
+         DefException)
+  TRUE)
+
+; Get error message
+(check
+  (try
+    (do (throw (new DefException "Custom exception")) NULL)
+    (catch DefException e (-> e (getMessage))))
+  "Custom exception")
+
+; Multiple catch
+(class-extends OtherException Exception)
+(check
+  (try
+    (do (throw (new OtherException "Other custom exception")) NULL)
+    (catch DefException e e)
+    (catch OtherException e (-> e (getMessage))))
+  "Other custom exception")
+
+; Capture tree
+(check
+  (try
+    (do
+      (try
+        (do (throw (new DefException "Custom exception")) NULL)
+        (catch OtherException e e)
+      ) NULL)
+    (catch DefException e (-> e (getMessage))))
+  "Custom exception")

--- a/pharen.php
+++ b/pharen.php
@@ -2283,6 +2283,72 @@ class LispyIfNode extends CondNode{
     }
 }
 
+class TryNode extends SpecialForm {
+    static $tmp_num = 0;
+
+    static function get_tmp_name(){
+        return "\$__trytmpvar".self::$tmp_num++;
+    }
+
+    public function compile(){
+        $tmp_var = self::get_tmp_name();
+        Node::$prev_tmp.= $this->format_line("").$this->compile_statement($tmp_var." = ");
+        return $tmp_var;
+    }
+
+    public function compile_statement($prefix="", $return=False){
+        $compile_func = $return ? "compile_return" : "compile_statement";
+
+        $code = !($prefix) ? "" :
+            $this->format_line("").$this->format_line("$prefix Null;");
+
+        $code .= $this->format_line("try {");
+        $code .= $this->children[1]->$compile_func($prefix);
+        $code .= $this->format_line("}");
+
+        foreach(array_slice($this->children, 2) as $children) {
+            //$children->indent = $this->parent instanceof RootNode ? "" : $this->parent->indent;
+            $children->indent = ($this->indent === Null) ? "" : $this->indent;
+            $code .= $children->$compile_func($prefix);
+        }
+
+        return $code;
+    }
+
+    public function compile_return(){
+      return $this->compile_statement(False, True);
+    }
+
+    public function get_last_func_call(){
+        return $this->children[sizeof($this->children) - 1]->get_last_func_call();
+    }
+
+    public function get_last_expr(){
+        return $this->children[sizeof($this->children) - 1];
+    }
+}
+
+class CatchNode extends TryNode {
+    public $type_name;
+
+    public function compile_statement($prefix="", $return=False){
+        $compile_func = $return ? "compile_return" : "compile_statement";
+
+        $type_name = $this->children[1]->compile();
+        $var_name  = $this->children[2]->compile();
+
+        $this->type_name = $type_name;
+
+        $this->children[3]->indent = $this->indent . "\t";
+
+        $code  = $this->format_line("catch ($type_name $var_name) {");
+        $code .= $this->children[3]->$compile_func($prefix);
+        $code .= $this->format_line("}");
+
+        return $code;
+    }
+}
+
 class ListAccessNode extends Node{
     static $tmp_var = 0;
 
@@ -2758,6 +2824,8 @@ class Parser{
             "do" => array("DoNode", "LeafNode", self::$values),
             "cond" => array("CondNode", "LeafNode", array(self::$cond_pair)),
             "if" => array("LispyIfNode", "LeafNode", self::$value, self::$value, self::$value),
+            "try" => array("TryNode", "LeafNode", self::$value, self::$values),
+            "catch" => array("CatchNode", "LeafNode", "LeafNode", "VariableNode", self::$value),
             "$" => array("SuperGlobalNode", "LeafNode", "LeafNode", self::$value),
             "def" => array("DefNode", "LeafNode", "VariableNode", self::$value),
             "local" => array("LocalNode", "LeafNode", "VariableNode", self::$value),

--- a/pharen.php
+++ b/pharen.php
@@ -2114,7 +2114,7 @@ class ClassNode extends SpecialForm{
     public function compile_statement(){
         $class_name = $this->children[1]->compile();
         $this->class_name = $class_name;
-        $body = $this->compile_body();
+        $body = isset($this->children[2]) ? $this->compile_body() : "";
         return $this->generate($class_name, $body);
     }
 }
@@ -2128,9 +2128,9 @@ class ClassExtendsNode extends ClassNode{
 
         $class_name = $this->children[1]->compile();
         $this->class_name = $class_name;
-        $parent_class = $this->children[2]->children[0]->value;
-        $body = $this->compile_body();
-        return $this->generate($class_name." extends ".$parent_class, $body);
+        $parent_class = $this->children[2]->compile();
+        $body = isset($this->children[3]) ? $this->compile_body() : "";
+        return $this->generate("$class_name extends $parent_class", $body);
     }
 }
 
@@ -2773,7 +2773,7 @@ class Parser{
             "::" => array("StaticCallNode", "LeafNode", "LeafNode", self::$values),
             "new" => array("InstantiationNode", "LeafNode", "LeafNode", self::$values),
             "class" => array("ClassNode", "LeafNode", "LeafNode", self::$values),
-            "class-extends" => array("ClassExtendsNode", "LeafNode", "LeafNode", self::$list_form, self::$values),
+            "class-extends" => array("ClassExtendsNode", "LeafNode", "LeafNode", "LeafNode", "LeafNode", self::$values),
             "access" => array("AccessModifierNode", "LeafNode", "LeafNode", self::$values),
             "interface" => array("InterfaceNode", "LeafNode", "LeafNode", self::$values),
             "signature*" => array("SignatureNode", "LeafNode", "LeafNode", "LeafNode", "LiteralNode"),


### PR DESCRIPTION
### try/catch

Adding try/catch clouse like a http://en.wikibooks.org/wiki/Clojure_Programming/Concepts#Exception_Handling

``` clojure
(fn exception ()
  (try
    (do (throw (new Exception "Custom")) NULL)
    (catch Exception e (-> e (getMessage)))))
(check (exception) "Custom")
```
### class
- For extends Exception class, I made the fix of `class-extends` clause.
- For more simple class added support blank class. 

``` clojure
(class-extends OtherException Exception)
```
### syntax suggestion
- Make support the class extends most like clojure http://en.wikibooks.org/wiki/Clojure_Programming/Concepts#User-Defined_Exceptions

``` clojure
(class OtherException :extends Exception)
(throw (new Exception "Custom"))
```
