### PR TITLE
Forward arguments to pharen when using pharen.bat

### DIFF
--- a/bin/pharen.bat
+++ b/bin/pharen.bat
@@ -1,3 +1,3 @@
 @echo off
 SET pharen_bin_dir=%~dp0
-php %pharen_bin_dir%\pharen
+php %pharen_bin_dir%\pharen %*


### PR DESCRIPTION
Running `pharen foo.phn` on Windows boots you into the pharen repl instead of compiling `foo.phn`. This is because the `pharen.bat` wrapper does not forward arguments it receives to the pharen bootstrap script. This pull request fixes that issue.
